### PR TITLE
Improve error handling, Implement comments

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -164,7 +164,7 @@ func parse(l *list.List) (map[Rule]map[string]string, error) {
 				value = token.value
 			case tokenValue:
 				if !isBlock { // descendant selector
-					rule = append(rule, token.value)
+					rule[len(rule)-1] += " " + token.value
 				} else { // technically, this could mean we put multiple style values.
 					if !isValue { // want to parse multiple style names? denied.
 						return css, fmt.Errorf("line %d: expected only one name before value: %w", token.pos.Line, InvalidCSSError)

--- a/parser.go
+++ b/parser.go
@@ -130,7 +130,7 @@ func buildList(r io.Reader) *list.List {
 func parse(l *list.List) (map[Rule]map[string]string, error) {
 	var (
 		// Information about the current block that is parsed.
-		rule     []string
+		rule     = make([]string, 1)
 		style    string
 		value    string
 		selector string
@@ -174,9 +174,14 @@ func parse(l *list.List) (map[Rule]map[string]string, error) {
 		case tokenValue:
 			switch prevToken {
 			case tokenFirstToken, tokenBlockEnd:
-				rule = append(rule, token.value)
+				rule[len(rule)-1] += token.value
 			case tokenSelector:
-				rule = append(rule, selector+token.value)
+				// if not empty - we already added a part of a rule and this is a descendant selector for that rule
+				if rule[len(rule)-1] != "" {
+					rule[len(rule)-1] += " "
+				}
+
+				rule[len(rule)-1] += selector + token.value
 			case tokenBlockStart, tokenStatementEnd: // { or ;
 				style = token.value
 			case tokenStyleSeparator:
@@ -237,7 +242,7 @@ func parse(l *list.List) (map[Rule]map[string]string, error) {
 			styles = map[string]string{}
 			style, value = "", ""
 			isBlock = false
-			rule = make([]string, 0)
+			rule = make([]string, 1)
 		}
 		prevToken = token.typ()
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -42,6 +42,11 @@ rule1 {
 	style1:value1;
 }`
 
+	ex7 := `rule1 {
+	/* this is a comment */
+	style: value;
+}`
+
 	cases := []struct {
 		name     string
 		CSS      string
@@ -84,6 +89,11 @@ rule1 {
 				"style1": "value1",
 			},
 		}},
+		{"Comment in rule", ex7, map[Rule]map[string]string{
+			"rule1": {
+				"style": "value",
+			},
+		}},
 	}
 
 	for _, tt := range cases {
@@ -118,7 +128,12 @@ rule {
 		style1: value1;
 		style2:;
 }`
-	_ = ex3
+
+	ex5 := `
+body {
+	style1:value1;
+	*/
+}`
 
 	cases := []struct {
 		name string
@@ -128,6 +143,7 @@ rule {
 		{"Missing style", ex2},
 		{"Statement Missing Semicolon", ex3},
 		{"BlockEndsWithoutBeginning", ex4},
+		{"Unexpected end of comment", ex5},
 	}
 
 	for _, tt := range cases {

--- a/parser_test.go
+++ b/parser_test.go
@@ -164,31 +164,6 @@ body {
 	}
 }
 
-func TestParseSelectorGroup(t *testing.T) {
-	ex1 := `.rule1 #rule2 rule3 {
-		style1: value1;
-		style2: value2;
-}`
-
-	css, err := Unmarshal([]byte(ex1))
-	if err != nil {
-		t.Fatal(err)
-	}
-	fmt.Println(css)
-
-	if _, ok := css[".rule1"]; !ok {
-		t.Fatal("Missing '.rule1' rule")
-	}
-	if _, ok := css["#rule2"]; !ok {
-		t.Fatal("Missing '#rule2' rule")
-	}
-	/*
-		if _, ok := css["rule3"]; !ok {
-			t.Fatal("Missing '.rule3' rule")
-		}
-	*/
-}
-
 func BenchmarkParser(b *testing.B) {
 	ex1 := ""
 	for i := 0; i < 100; i++ {

--- a/parser_test.go
+++ b/parser_test.go
@@ -47,6 +47,10 @@ rule1 {
 	style: value;
 }`
 
+	ex8 := `.rule1 #rule2 {
+	style: value;
+}`
+
 	cases := []struct {
 		name     string
 		CSS      string
@@ -91,6 +95,11 @@ rule1 {
 		}},
 		{"Comment in rule", ex7, map[Rule]map[string]string{
 			"rule1": {
+				"style": "value",
+			},
+		}},
+		{"Selector with descentant ID and Class", ex8, map[Rule]map[string]string{
+			".rule1 #rule2": {
 				"style": "value",
 			},
 		}},
@@ -165,6 +174,7 @@ func TestParseSelectorGroup(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	fmt.Println(css)
 
 	if _, ok := css[".rule1"]; !ok {
 		t.Fatal("Missing '.rule1' rule")
@@ -172,9 +182,11 @@ func TestParseSelectorGroup(t *testing.T) {
 	if _, ok := css["#rule2"]; !ok {
 		t.Fatal("Missing '#rule2' rule")
 	}
-	if _, ok := css["rule3"]; !ok {
-		t.Fatal("Missing '.rule3' rule")
-	}
+	/*
+		if _, ok := css["rule3"]; !ok {
+			t.Fatal("Missing '.rule3' rule")
+		}
+	*/
 }
 
 func BenchmarkParser(b *testing.B) {

--- a/parser_test.go
+++ b/parser_test.go
@@ -38,6 +38,10 @@ rule1 {
     background-repeat: repeat-x;
 }`
 
+	ex6 := `rule1 descendant {
+	style1:value1;
+}`
+
 	cases := []struct {
 		name     string
 		CSS      string
@@ -73,6 +77,11 @@ rule1 {
 			"body": {
 				"background-image":  "url(\"gradient_bg.png\")",
 				"background-repeat": "repeat-x",
+			},
+		}},
+		{"Descendant selector", ex6, map[Rule]map[string]string{
+			"rule1 descendant": {
+				"style1": "value1",
 			},
 		}},
 	}
@@ -117,8 +126,7 @@ rule {
 	}{
 		{"Missing rule", ex1},
 		{"Missing style", ex2},
-		// TODO: this hsould not crash
-		//{"Statement Missing Semicolon", ex3},
+		{"Statement Missing Semicolon", ex3},
 		{"BlockEndsWithoutBeginning", ex4},
 	}
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -155,28 +155,6 @@ body {
 	}
 }
 
-func TestParseSelectors(t *testing.T) {
-	ex1 := `.rule {
-		style1: value1;
-		style2: value2;
-}
-#rule1 sad asd {
-	style3: value3;
-	style4: value4;
-}`
-
-	css, err := Unmarshal([]byte(ex1))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, ok := css[".rule"]; !ok {
-		t.Fatal("Missing '.rule' rule")
-	}
-	if _, ok := css["#rule1"]; !ok {
-		t.Fatal("Missing '.rule' rule")
-	}
-}
-
 func TestParseSelectorGroup(t *testing.T) {
 	ex1 := `.rule1 #rule2 rule3 {
 		style1: value1;

--- a/tokentype_string.go
+++ b/tokentype_string.go
@@ -16,11 +16,13 @@ func _() {
 	_ = x[tokenSelector-4]
 	_ = x[tokenStyleSeparator-5]
 	_ = x[tokenStatementEnd-6]
+	_ = x[tokenCommentStart-7]
+	_ = x[tokenCommentEnd-8]
 }
 
-const _tokenType_name = "tokenFirstTokentokenBlockStarttokenBlockEndtokenRuleNametokenValuetokenSelectortokenStyleSeparatortokenStatementEnd"
+const _tokenType_name = "tokenFirstTokentokenBlockStarttokenBlockEndtokenRuleNametokenValuetokenSelectortokenStyleSeparatortokenStatementEndtokenCommentStarttokenCommentEnd"
 
-var _tokenType_index = [...]uint8{0, 15, 30, 43, 56, 66, 79, 98, 115}
+var _tokenType_index = [...]uint8{0, 15, 30, 43, 56, 66, 79, 98, 115, 132, 147}
 
 func (i tokenType) String() string {
 	i -= -1


### PR DESCRIPTION
This does the following
- Implement comment
- re-add commented-out testcase and make parser crash correctly
   * there was a bug causing, that missing `;` didn't cause error
- fix behaviour on so called [descendant](https://developer.mozilla.org/en-US/docs/Web/CSS/Descendant_combinator) rules (now it makes rules like `rule asdf fdsa` another css rule index)